### PR TITLE
Fixed bug related to notes view.

### DIFF
--- a/server/controllers/dashboardController.js
+++ b/server/controllers/dashboardController.js
@@ -60,7 +60,7 @@ exports.dashboardViewNote = async(req,res) => {
 
 
     if(note){
-        res.render('dashboard/view-note',{
+        res.render('dashboard/view-notes',{
             noteID: req.params.id,
             note,
             layout: '../views/layouts/dashboard'

--- a/views/dashboard/index.ejs
+++ b/views/dashboard/index.ejs
@@ -14,7 +14,7 @@
 
             <div class="col-sm-3 mb-4">
                 <div class="card border-primary" style="min-height: 210px">
-                    <a href="/dashboard/item/ <%= notes[i]._id %>" class="card-body text-decoration-none">
+                    <a href="/dashboard/item/<%= notes[i]._id %>" class="card-body text-decoration-none">
                         <h5 class="card-title"><%= notes[i].title %></h5>
                         <p class="card-text"><%= notes[i].body %></p>
                     </a>


### PR DESCRIPTION
## Fixed:
Notes cannot be viewed by clicking.

## Issue:
closes #5 

## Summary:
There were some white space problems in the URL when clicking a note. That white space is read as **%**, which is getting translated to the wrong ID. Additionally, there is a typo in the dashboardController.js file, which I have highlighted in the screenshots below. If there's anything left, please let me know. 

## Underlying problem:
1. White space error in URL when the note is clicked.
2. Wrong endpoint mentioned in **dashboardController.js**.

### Before:
![Screenshot from 2025-06-17 16-14-20](https://github.com/user-attachments/assets/b7a56f5a-dfc1-496a-be33-2582c362f3f2)

### After:
![Screenshot from 2025-06-17 16-14-28](https://github.com/user-attachments/assets/f7e7167a-806e-40bf-ad08-a981aa72aa51)

## Screenshots of test:
![Screenshot from 2025-06-17 16-09-14](https://github.com/user-attachments/assets/d266893e-9be7-4548-bb2f-40df8009a833)
![Screenshot from 2025-06-17 16-09-28](https://github.com/user-attachments/assets/dc988326-e67d-4580-aed1-f47ec92ae7c8)
![Screenshot from 2025-06-17 16-09-37](https://github.com/user-attachments/assets/04cc3ff9-c1b9-43b3-a461-59127b19cca0)

