### PR TITLE
✨ Added Dark Mode Toggle with Styling

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -88,3 +88,96 @@ h1,h2,h3,h4,h5,h6{
     right: -50px;
     bottom: -30px;
 }
+
+/* Dark Theme Variables */
+[data-theme="dark"] {
+  --background-color: #1e1e2f;
+  --bs-primary-rgb: #f3f3f3;
+
+  --bs-btn-bg: #123C69;
+  --bs-btn-border-color: #123C69;
+  --bs-btn-hover-bg: #325993;
+  --bs-btn-hover-border-color: #325993;
+
+  --bs-btn-color: #fff;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-active-color: #fff;
+  --bs-btn-disabled-color: #ccc;
+
+  --bs-pagination-color: #f3f3f3;
+  --bs-pagination-active-bg: #f3f3f3;
+  --bs-pagination-active-border-color: #f3f3f3;
+}
+
+[data-theme="dark"] body {
+  background-color: var(--background-color) !important;
+  color: var(--bs-primary-rgb) !important;
+}
+
+[data-theme="dark"] h1,
+[data-theme="dark"] h2,
+[data-theme="dark"] h3,
+[data-theme="dark"] h4,
+[data-theme="dark"] h5,
+[data-theme="dark"] h6 {
+  color: var(--bs-primary-rgb) !important;
+}
+
+[data-theme="dark"] .btn,
+[data-theme="dark"] .btn-primary,
+[data-theme="dark"] .btn-outline-primary {
+  color: var(--bs-btn-color) !important;
+  background-color: var(--bs-btn-bg) !important;
+  border-color: var(--bs-btn-border-color) !important;
+}
+
+[data-theme="dark"] .btn:hover,
+[data-theme="dark"] .btn-primary:hover,
+[data-theme="dark"] .btn-outline-primary:hover {
+  background-color: var(--bs-btn-hover-bg) !important;
+  color: white !important;
+  border-color: var(--bs-btn-hover-border-color) !important;
+}
+
+[data-theme="dark"] .pagination {
+  color: var(--bs-pagination-color) !important;
+}
+
+[data-theme="dark"] .pagination .active .page-link {
+  background-color: var(--bs-pagination-active-bg) !important;
+  border-color: var(--bs-pagination-active-border-color) !important;
+}
+
+[data-theme="dark"] .home-title::before,
+[data-theme="dark"] .home-title::after {
+  filter: brightness(0) invert(1);
+}
+
+
+  [data-theme="dark"] {
+    --background-color: #1e1e2f;
+    --bs-primary-rgb: #f3f3f3;
+  }
+
+  [data-theme="dark"] body {
+    background-color: var(--background-color) !important;
+    color: var(--bs-primary-rgb) !important;
+  }
+
+  [data-theme="dark"] .btn-primary,
+  [data-theme="dark"] .btn-outline-primary {
+    background-color: #fff !important;
+    border-color: #325993 !important;
+    color: #325993 !important;
+
+  }
+
+
+  [data-theme="dark"] .nav-link {
+    color: #f1f1f1 !important;
+  }
+
+  [data-theme="dark"] .btn-outline-light {
+    border-color: #ccc !important;
+    color: #ccc !important;
+  }

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,19 +1,47 @@
-<div class="container-fluid">
-    <header class="d-flex flex-wrap align-items-center justify-content-center justify-content-md-between py-3 mb-4 ">
-      <a href="/" class="d-flex align-items-center col-md-3 mb-2 mb-md-0 text-primary text-decoration-none fw-bold fs-2">
-        NotesApp
-      </a>
+  <div class="container-fluid">
+  <header class="d-flex flex-wrap align-items-center justify-content-center justify-content-md-between py-3 mb-4">
+    <a href="/" class="d-flex align-items-center col-md-3 mb-2 mb-md-0 text-primary text-decoration-none fw-bold fs-2">
+      NotesApp
+    </a>
 
-      <ul class="nav col-12 col-md-auto mb-2 justify-content-center mb-md-0">
-        <li><a href="/" class="nav-link px-2 link-secondary">Home</a></li>
-        <li><a href="#" class="nav-link px-2 link-dark">Features</a></li>
-        <li><a href="#" class="nav-link px-2 link-dark">FAQs</a></li>
-        <li><a href="/about" class="nav-link px-2 link-dark">About</a></li>
-      </ul>
+    <ul class="nav col-12 col-md-auto mb-2 justify-content-center mb-md-0">
+      <li><a href="/" class="nav-link px-2 link-secondary">Home</a></li>
+      <li><a href="#" class="nav-link px-2 link-dark">Features</a></li>
+      <li><a href="#" class="nav-link px-2 link-dark">FAQs</a></li>
+      <li><a href="/about" class="nav-link px-2 link-dark">About</a></li>
+    </ul>
 
-      <div class="col-md-3 text-end">
-        <a href="/auth/google" type="button" class="btn btn-outline-primary me-2">Login</a>
-        <a href="/auth/google" type="button" class="btn btn-primary">Sign-up</a>
-      </div>
-    </header>
-  </div>
+    <div class="col-md-3 text-end">
+      <a href="/auth/google" type="button" class="btn btn-outline-primary me-2">Login</a>
+      <a href="/auth/google" type="button" class="btn btn-primary">Sign-up</a>
+      <button id="theme-toggle" class="btn btn-outline-primary ms-2">🌙</button>
+    </div>
+  </header>
+</div> 
+
+<!--  Dark Mode Toggle Script -->
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const toggleBtn = document.getElementById("theme-toggle");
+    const root = document.documentElement;
+    const savedTheme = localStorage.getItem("theme");
+
+    function applyTheme(theme) {
+      root.setAttribute("data-theme", theme);
+      toggleBtn.textContent = theme === "dark" ? "🌞" : "🌙";
+      localStorage.setItem("theme", theme);
+    }
+
+    if (savedTheme) {
+      applyTheme(savedTheme);
+    } else {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      applyTheme(prefersDark ? "dark" : "light");
+    }
+
+    toggleBtn.addEventListener("click", () => {
+      const current = root.getAttribute("data-theme");
+      applyTheme(current === "dark" ? "light" : "dark");
+    });
+  });
+</script>


### PR DESCRIPTION
This PR adds dark mode support to the Notes App using a simple toggle button in the navbar. Users can switch between light and dark themes, and their preference is saved in localStorage to persist across sessions. The feature improves user experience, especially in low-light environments.

💻 Implementation Details:
Added a 🌙/🌞 theme toggle button in header.ejs

JavaScript logic for toggling themes is included in the same header.ejs file

Dark mode styles are integrated directly into the existing main.css using [data-theme="dark"] selectors

Includes Bootstrap-compatible styling for buttons and nav links in dark mode

🧪 How to Test:
Start the app and navigate to any page with the navbar.

Click the theme toggle button to switch between light and dark mode.

Verify that styles update accordingly and the preference is saved.

Refresh the page — theme preference should remain the same.

📁 Files Modified:
views/partials/header.ejs

public/css/main.css

